### PR TITLE
[GREEN-844] Add login instructions to Readme files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+#### JIRA
+[TEAM-123](https://testlions.atlassian.net/browse/TEAM-123)
+
+#### Related PRs
+- none
+
+#### Background and Solution
+Please describe the background and implementation of the feature or fix.
+
+#### Testing Strategy
+
+#### Templates Affected
+[] Mobile Java TestNG
+[] Mobile Node 
+[] Web Java TestNG

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # testlio-automation-templates
+
+* [Mobile Java TestNG template](./testlio-mobile-java-testng-template/README.md)
+* [Mobile Node template](./testlio-mobile-node-template/README.md)
+* [Web Java TestNG template](./testlio-web-java-testng-template/README.md)

--- a/testlio-mobile-java-testng-template/README.md
+++ b/testlio-mobile-java-testng-template/README.md
@@ -25,6 +25,13 @@ mvn install:install-file \
    -DgeneratePom=true
 ```
 
+## Run Tests
+Create a `credentials.properties` file in the directory `src/test/resources` with the values from `Android Testlio Mobile Login Sample App` in 1pass as follows:
+ ```bash
+ user.username=<username>
+ user.password=<password>
+ ```
+
 ## Run tests locally
 ### Android
 ```bash 

--- a/testlio-mobile-java-testng-template/src/test/java/com/testlio/tests/TestlioLoginTest.java
+++ b/testlio-mobile-java-testng-template/src/test/java/com/testlio/tests/TestlioLoginTest.java
@@ -12,14 +12,6 @@ import static com.testlio.constants.MobileAppStrings.SUCCESSFUL_LOGIN_ALERT_TITL
 import static com.testlio.lib.pagefactory.TestlioPageFactory.initMobileElements;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Before running/packaging this test, ensure,
- * that you created credentials.properties file
- * in directory src/test/resources with following content:
- *
- * user.username=testlio
- * user.password=lovetesting
- */
 public class TestlioLoginTest extends BaseTest {
 
     /**

--- a/testlio-mobile-node-template/README.md
+++ b/testlio-mobile-node-template/README.md
@@ -9,6 +9,13 @@
 - `wdio.local.conf.ts` - WebdriverIO config for local test execution
 - `wdio.testlio.conf.ts` - WebdriverIO config for test execution on Testlio platform (please do not change it)
 
+## Run tests
+Add the login credentials to `config.ts` file from `Android Testlio Mobile Login Sample App` in 1pass as follows:
+```bash 
+username=<username>
+password=<password>
+```
+
 ## Run tests locally
 
 1. Install the dependencies:

--- a/testlio-web-java-testng-template/README.md
+++ b/testlio-web-java-testng-template/README.md
@@ -25,8 +25,14 @@ mvn install:install-file \
    -DgeneratePom=true
 ```
 
-## Run tests locally
+## Run tests
+Create a `credentials.properties` file in the directory `src/test/resources` with the values from `Android Testlio Mobile Login Sample App` in 1pass as follows:
+ ```bash
+ user.username=<username>
+ user.password=<password>
+ ```
 
+## Run tests locally
 ### Desktop
 ```bash 
 mvn clean test \

--- a/testlio-web-java-testng-template/src/test/java/com/testlio/tests/TestlioLoginTest.java
+++ b/testlio-web-java-testng-template/src/test/java/com/testlio/tests/TestlioLoginTest.java
@@ -8,14 +8,6 @@ import java.util.ResourceBundle;
 
 import static com.testlio.constants.WebAppUrls.PLATFORM_TESTLIO_URL;
 
-/**
- * Before running/packaging this test, ensure,
- * that you created credentials.properties file
- * in directory src/test/resources with following content:
- *
- * user.email=<put your testlio account email>
- * user.password=<put your testlio account password>
- */
 public class TestlioLoginTest extends BaseTest {
 
     /**


### PR DESCRIPTION
#### JIRA
[GREEN-844](https://testlions.atlassian.net/browse/GREEN-844)

#### Related PRs
- none

#### Background and Solution
* Move login instructions to the templates readme
* Moved credentials to 1pass (`Android Testlio Mobile Login Sample App`)

#### Testing Strategy

#### Templates Affected
[x] Mobile Java TestNG
[x] Mobile Node 
[x] Web Java TestNG